### PR TITLE
auto-website-snapshot-fix

### DIFF
--- a/.github/workflows/website-screenshot.yml
+++ b/.github/workflows/website-screenshot.yml
@@ -2,9 +2,10 @@ name: website-screenshot
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - "*"
   pull_request:
-    branches: [ master ]
+    branches:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/website-screenshot.yml
+++ b/.github/workflows/website-screenshot.yml
@@ -17,7 +17,7 @@ jobs:
         persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
         fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
 
-    - name: Screenshot Website
+    - name: Screenshot website
       uses: swinton/screenshot-website@v1.x
       with:
         source: https://raidionics.github.io/
@@ -29,7 +29,7 @@ jobs:
       with:
         github_token: ${{secrets.CI_TOKEN}}
         workflow: website-screenshot.yml
-        workflow_conclusion: success
+        workflow_conclusion: ""
         branch: master
         event: push
         name: screenshot

--- a/.github/workflows/website-screenshot.yml
+++ b/.github/workflows/website-screenshot.yml
@@ -23,6 +23,18 @@ jobs:
         source: https://raidionics.github.io/
         destination: screenshot.png
     
+    - name: Download artifact
+      uses: dawidd6/action-download-artifact@v2
+      continue-on-error: false
+      with:
+        github_token: ${{secrets.CI_TOKEN}}
+        workflow: website-screenshot.yml
+        workflow_conclusion: success
+        branch: master
+        event: push
+        name: screenshot
+        repo: raidionics/raidionics.github.io
+    
     - name: Debug
       run: ls -haltr
 

--- a/.github/workflows/website-screenshot.yml
+++ b/.github/workflows/website-screenshot.yml
@@ -33,7 +33,7 @@ jobs:
         branch: master
         event: push
         name: screenshot
-        repo: andreped/raidionics.github.io
+        repo: raidionics/raidionics.github.io
     
     - name: Debug
       run: ls -haltr
@@ -41,7 +41,7 @@ jobs:
     - name: Update screenshot in release
       uses: svenstaro/upload-release-action@v2
       with:
-        repo_name: andreped/raidionics.github.io
+        repo_name: raidionics/raidionics.github.io
         repo_token: ${{ secrets.CI_TOKEN }}
         file: ${{github.workspace}}/screenshot.png
         asset_name: screenshot.png

--- a/.github/workflows/website-screenshot.yml
+++ b/.github/workflows/website-screenshot.yml
@@ -33,7 +33,7 @@ jobs:
         branch: master
         event: push
         name: screenshot
-        repo: raidionics/raidionics.github.io
+        repo: andreped/raidionics.github.io
     
     - name: Debug
       run: ls -haltr
@@ -41,7 +41,7 @@ jobs:
     - name: Update screenshot in release
       uses: svenstaro/upload-release-action@v2
       with:
-        repo_name: raidionics/raidionics.github.io
+        repo_name: andreped/raidionics.github.io
         repo_token: ${{ secrets.CI_TOKEN }}
         file: ${{github.workspace}}/screenshot.png
         asset_name: screenshot.png

--- a/.github/workflows/website-screenshot.yml
+++ b/.github/workflows/website-screenshot.yml
@@ -21,6 +21,9 @@ jobs:
       with:
         source: https://raidionics.github.io/
         destination: screenshot.png
+    
+    - name: Debug
+      run: ls -haltr
 
     - name: Update screenshot in release
       uses: svenstaro/upload-release-action@v2

--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 [![Website raidionics.github.io](https://img.shields.io/website-up-down-green-red/https/raidionics.github.io.svg)](https://raidionics.github.io/)
 
-<img src="https://github.com/andreped/raidionics.github.io/releases/download/screenshot-website/screenshot.png" width="70%" height="70%">
+<img src="https://github.com/andreped/raidionics.github.io/releases/download/screenshot-website/screenshot.png" width="100%" height="100%">
 
 Automatically generated snapshot of the current state of the website (created after a successful commit and deployment).

--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 [![Website raidionics.github.io](https://img.shields.io/website-up-down-green-red/https/raidionics.github.io.svg)](https://raidionics.github.io/)
 
-<img src="https://github.com/andreped/raidionics.github.io/releases/download/screenshot-website/screenshot.png" width="100%" height="100%">
+<img src="https://github.com/raidionics/raidionics.github.io/releases/download/screenshot-website/screenshot.png" width="100%" height="100%">
 
 Automatically generated snapshot of the current state of the website (created after a successful commit and deployment).

--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 [![Website raidionics.github.io](https://img.shields.io/website-up-down-green-red/https/raidionics.github.io.svg)](https://raidionics.github.io/)
 
-<img src="screenshot.png" width="100%" height="100%">
+<img src="https://github.com/andreped/raidionics.github.io/releases/download/screenshot-website/screenshot.png" width="70%" height="70%">
 
 Automatically generated snapshot of the current state of the website (created after a successful commit and deployment).


### PR DESCRIPTION
When attempting to upload the screenshot in the release tag, I was prompted that `repo_token` was not set.

However, that was the case. It appeared that the main issue was that the screenshot.png was only stored as an artifact but not downloaded into the repo in the CI, which is required in order to upload it.

I made the necessary adjustments. At least it worked fine on my fork, but I needed to change the URL paths back to `raidionics/raidionics.github.io` instead of my own fork `andreped`.