### PR TITLE
Fixed gif and added favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <title>Raidionics</title>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🧠</text></svg>">
 <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Raleway">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">


### PR DESCRIPTION
* Resized Slicer gif to match size of corresponding Raidionics gif
* Added favicon, which should be displayed in the browser header

Note that the original Slicer gif is of _very_ poor quality. Hence, the resized gif is as well. It could be an idea to redo both these gifs, on a single computer with the same display resolution, to get two gifs that look more consistent in quality. But for now, it is probably fine.